### PR TITLE
Try add string length limit

### DIFF
--- a/LazyUtils/ConfigBase.cs
+++ b/LazyUtils/ConfigBase.cs
@@ -23,6 +23,7 @@ public abstract class ConfigBase<T> where T : ConfigBase<T>
         }
         public Context(string tableName) : base(GetProvider(), ConfigBase<T>.ConnectionString)
         {
+            this.MappingSchema.AddScalarType(typeof(string), new LinqToDB.SqlQuery.SqlDataType(DataType.NVarChar, 255));
             this.CreateTable<T>(tableName, tableOptions: TableOptions.CreateIfNotExists);
         }
     }

--- a/OnlineInfo/Utils.cs
+++ b/OnlineInfo/Utils.cs
@@ -45,7 +45,9 @@ internal static class Utils
 
     public static DataConnection GetDBConnection()
     {
-        return new DataConnection(DBProvider, DBConnectionString);
+        var dc = new DataConnection(DBProvider, DBConnectionString);
+        dc.MappingSchema.AddScalarType(typeof(string), new LinqToDB.SqlQuery.SqlDataType(DataType.NVarChar, 255));
+        return dc;
     }
 
     public static DisposableQuery<T> GetDBQuery<T>() where T : class


### PR DESCRIPTION
手动设置字符串长度限制以避免linq2db默认字符串的varchar(4000)长度超出主键限制1000 byte

测试后再合并